### PR TITLE
Update NFT contract address

### DIFF
--- a/packages/nextjs/contracts/externalContracts.ts
+++ b/packages/nextjs/contracts/externalContracts.ts
@@ -301,7 +301,7 @@ const externalContracts = {
       },
     },
     BatchGraduationNFT: {
-      address: "0x0",
+      address: "0x12b6ec1EeE38CaDc477CDC2e82840F258e1bA5DB",
       abi: [
         {
           inputs: [


### PR DESCRIPTION
## Description

Adds a missing address in `externalContracts.ts` so that the `Debug Contracts` page can render correctly.
<img width="1092" alt="Screenshot 2024-09-06 at 10 53 18 AM" src="https://github.com/user-attachments/assets/759cf5cf-24e4-4518-b818-22cf91b1e308">

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: rhymeswithesoteric.eth 