### PR TITLE
Issue 7 - Create builders list page

### DIFF
--- a/packages/nextjs/app/builders/_components/BuilderPicture.tsx
+++ b/packages/nextjs/app/builders/_components/BuilderPicture.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
+import Link from "next/link";
 import { Builder } from "~~/types/builders";
-import Link from 'next/link';
 
 type ProfilePictureProps = {
   person: Builder;

--- a/packages/nextjs/app/builders/_components/BuilderPicture.tsx
+++ b/packages/nextjs/app/builders/_components/BuilderPicture.tsx
@@ -3,12 +3,11 @@ import { Builder } from "~~/types/builders";
 
 type ProfilePictureProps = {
   person: Builder;
-  key: number;
 };
 
-export const BuilderPicture = ({ person, key }: ProfilePictureProps) => {
+export const BuilderPicture = ({ person }: ProfilePictureProps) => {
   return (
-    <div key={key} className="text-center">
+    <div className="text-center">
       <a href={person.link} className="link" target="_blank" rel="noopener noreferrer">
         <Image
           width={100}

--- a/packages/nextjs/app/builders/_components/BuilderPicture.tsx
+++ b/packages/nextjs/app/builders/_components/BuilderPicture.tsx
@@ -1,5 +1,5 @@
-import Image from "next/image";
 import Link from "next/link";
+import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { Builder } from "~~/types/builders";
 
 type ProfilePictureProps = {
@@ -9,14 +9,8 @@ type ProfilePictureProps = {
 export const BuilderPicture = ({ person }: ProfilePictureProps) => {
   return (
     <div className="text-center">
-      <Link href={person.link} className="link" rel="noopener noreferrer">
-        <Image
-          width={100}
-          height={100}
-          className="w-24 h-24 rounded-full mx-auto"
-          src={person.image}
-          alt={person.link}
-        />
+      <Link href={person.profileLink} className="link" rel="noopener noreferrer">
+        <BlockieAvatar address={person.address as `0x${string}`} size={100} />
         See profile
       </Link>
     </div>

--- a/packages/nextjs/app/builders/_components/BuilderPicture.tsx
+++ b/packages/nextjs/app/builders/_components/BuilderPicture.tsx
@@ -2,25 +2,20 @@ import Image from "next/image";
 import { Builder } from "~~/types/builders";
 
 type ProfilePictureProps = {
-  builder: Builder;
+  person: Builder;
   key: number;
 };
 
-export const ProfilePicture = ({ builder, key }: ProfilePictureProps) => {
+export const BuilderPicture = ({ person, key }: ProfilePictureProps) => {
   return (
     <div key={key} className="text-center">
-      <a
-        href={builder.link}
-        className="mt-2 block text-blue-600 hover:underline font-medium"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <a href={person.link} className="link" target="_blank" rel="noopener noreferrer">
         <Image
           width={100}
           height={100}
           className="w-24 h-24 rounded-full mx-auto"
-          src={builder.image}
-          alt={builder.link}
+          src={person.image}
+          alt={person.link}
         />
         See profile
       </a>

--- a/packages/nextjs/app/builders/_components/BuilderPicture.tsx
+++ b/packages/nextjs/app/builders/_components/BuilderPicture.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Builder } from "~~/types/builders";
+import Link from 'next/link';
 
 type ProfilePictureProps = {
   person: Builder;
@@ -8,7 +9,7 @@ type ProfilePictureProps = {
 export const BuilderPicture = ({ person }: ProfilePictureProps) => {
   return (
     <div className="text-center">
-      <a href={person.link} className="link" target="_blank" rel="noopener noreferrer">
+      <Link href={person.link} className="link" rel="noopener noreferrer">
         <Image
           width={100}
           height={100}
@@ -17,7 +18,7 @@ export const BuilderPicture = ({ person }: ProfilePictureProps) => {
           alt={person.link}
         />
         See profile
-      </a>
+      </Link>
     </div>
   );
 };

--- a/packages/nextjs/app/builders/_components/MentorPicture.tsx
+++ b/packages/nextjs/app/builders/_components/MentorPicture.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
+import Link from "next/link";
 import { Mentor } from "~~/types/builders";
-import Link from 'next/link';
 
 type ProfilePictureProps = {
   person: Mentor;

--- a/packages/nextjs/app/builders/_components/MentorPicture.tsx
+++ b/packages/nextjs/app/builders/_components/MentorPicture.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Mentor } from "~~/types/builders";
+import Link from 'next/link';
 
 type ProfilePictureProps = {
   person: Mentor;
@@ -8,7 +9,7 @@ type ProfilePictureProps = {
 export const MentorPicture = ({ person }: ProfilePictureProps) => {
   return (
     <div className="text-center">
-      <a href={person.link} className="link" target="_blank" rel="noopener noreferrer">
+      <Link href={person.link} className="link" target="_blank" rel="noopener noreferrer">
         <Image
           width={100}
           height={100}
@@ -17,7 +18,7 @@ export const MentorPicture = ({ person }: ProfilePictureProps) => {
           alt={person.link}
         />
         {person.name}
-      </a>
+      </Link>
     </div>
   );
 };

--- a/packages/nextjs/app/builders/_components/MentorPicture.tsx
+++ b/packages/nextjs/app/builders/_components/MentorPicture.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+import { Mentor } from "~~/types/builders";
+
+type ProfilePictureProps = {
+  person: Mentor;
+  key: number;
+};
+
+export const MentorPicture = ({ person, key }: ProfilePictureProps) => {
+  return (
+    <div key={key} className="text-center">
+      <a href={person.link} className="link" target="_blank" rel="noopener noreferrer">
+        <Image
+          width={100}
+          height={100}
+          className="w-24 h-24 rounded-full mx-auto"
+          src={person.image}
+          alt={person.link}
+        />
+        {person.name}
+      </a>
+    </div>
+  );
+};

--- a/packages/nextjs/app/builders/_components/MentorPicture.tsx
+++ b/packages/nextjs/app/builders/_components/MentorPicture.tsx
@@ -3,12 +3,11 @@ import { Mentor } from "~~/types/builders";
 
 type ProfilePictureProps = {
   person: Mentor;
-  key: number;
 };
 
-export const MentorPicture = ({ person, key }: ProfilePictureProps) => {
+export const MentorPicture = ({ person }: ProfilePictureProps) => {
   return (
-    <div key={key} className="text-center">
+    <div className="text-center">
       <a href={person.link} className="link" target="_blank" rel="noopener noreferrer">
         <Image
           width={100}

--- a/packages/nextjs/app/builders/_components/MentorPicture.tsx
+++ b/packages/nextjs/app/builders/_components/MentorPicture.tsx
@@ -9,13 +9,13 @@ type ProfilePictureProps = {
 export const MentorPicture = ({ person }: ProfilePictureProps) => {
   return (
     <div className="text-center">
-      <Link href={person.link} className="link" target="_blank" rel="noopener noreferrer">
+      <Link href={person.profileLink} className="link" target="_blank" rel="noopener noreferrer">
         <Image
           width={100}
           height={100}
           className="w-24 h-24 rounded-full mx-auto"
           src={person.image}
-          alt={person.link}
+          alt={person.profileLink}
         />
         {person.name}
       </Link>

--- a/packages/nextjs/app/builders/_components/ProfilePicture.tsx
+++ b/packages/nextjs/app/builders/_components/ProfilePicture.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+import { Builder } from "~~/types/builders";
+
+type ProfilePictureProps = {
+  builder: Builder;
+  key: number;
+};
+
+export const ProfilePicture = ({ builder, key }: ProfilePictureProps) => {
+  return (
+    <div key={key} className="text-center">
+      <a
+        href={builder.link}
+        className="mt-2 block text-blue-600 hover:underline font-medium"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Image
+          width={100}
+          height={100}
+          className="w-24 h-24 rounded-full mx-auto"
+          src={builder.image}
+          alt={builder.link}
+        />
+        See profile
+      </a>
+    </div>
+  );
+};

--- a/packages/nextjs/app/builders/_components/index.tsx
+++ b/packages/nextjs/app/builders/_components/index.tsx
@@ -1,0 +1,2 @@
+export * from "./MentorPicture";
+export * from "./BuilderPicture";

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -19,7 +19,8 @@ const getRandomUserImage = () => {
 
 const getBuilderFromEvent = (event: any): Builder => ({
   image: getRandomUserImage(),
-  link: "builders/" + event.args.builder,
+  profileLink: "builders/" + event.args.builder,
+  address: event.args.builder,
   checkedIn: true,
 });
 
@@ -27,19 +28,20 @@ const mentors: Mentor[] = [
   {
     name: "Eda",
     image: "https://avatars.githubusercontent.com/u/22100698?v=4",
-    link: "https://github.com/edakturk14",
+    profileLink: "https://github.com/edakturk14",
     checkedIn: false,
   },
   {
     name: "Derrek",
     image: "https://avatars.githubusercontent.com/u/80121818?v=4",
-    link: "https://github.com/derrekcoleman",
+    profileLink: "https://github.com/derrekcoleman",
+
     checkedIn: false,
   },
   {
     name: "Philip",
     image: "https://avatars.githubusercontent.com/u/90064316?v=4",
-    link: "https://github.com/phipsae",
+    profileLink: "https://github.com/phipsae",
     checkedIn: false,
   },
 ];

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,0 +1,96 @@
+import type { NextPage } from "next";
+import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+
+export const metadata = getMetadata({
+  title: "Builders",
+  description: "List of members of the batch #9",
+});
+
+const getRandomGender = () => {
+  return Math.random() < 0.5 ? "men" : "women";
+};
+
+const getRandomUserImage = () => {
+  const randomInt = Math.floor(Math.random() * 50);
+  const randomGender = getRandomGender();
+
+  return `https://randomuser.me/api/portraits/${randomGender}/${randomInt}.jpg`;
+};
+
+const mentors = [
+  { name: "Mentor 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000" },
+  { name: "Mentor 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000" },
+  { name: "Mentor 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000" },
+];
+
+const builders = [
+  { name: "Builder 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
+  { name: "Builder 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: false },
+  { name: "Builder 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
+  { name: "Builder 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
+  { name: "Builder 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: false },
+  { name: "Builder 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
+  { name: "Builder 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
+  { name: "Builder 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: false },
+  { name: "Builder 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
+];
+
+const Builders: NextPage = () => {
+  const totalBuilders = builders.length;
+  const buildersCheckedIn = builders.filter(builder => builder.checkIn).length;
+
+  return (
+    <>
+      <div className="text-center bg-secondary p-10">
+        <h1 className="text-4xl my-0">Builders</h1>
+      </div>
+      <div className="max-w-screen-lg mx-auto mt-10 p-6 bg-base-300 shadow-md rounded-lg">
+        <div className="container mx-auto px-4 py-8">
+          <h1 className="text-sm font-bold text-center mb-8">
+            Builders that checkedIn: {buildersCheckedIn} de {totalBuilders}
+          </h1>
+
+          <div className="mb-12">
+            <h2 className="text-2xl font-semibold text-center mb-6">Mentors</h2>
+            <div className="grid grid-cols-3 gap-6">
+              {mentors.map(mentor => (
+                <div key={mentor.name} className="text-center">
+                  <img className="w-24 h-24 rounded-full mx-auto" src={mentor.imgUrl} alt={mentor.name} />
+                  <a
+                    href={mentor.link}
+                    className="mt-2 block text-blue-600 hover:underline font-medium"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {mentor.name}
+                  </a>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-center mb-6">Builders 🏗</h2>
+            <div className="grid grid-cols-6 gap-6">
+              {builders.map(builder => (
+                <div key={builder.name} className="text-center">
+                  <img className="w-24 h-24 rounded-full mx-auto" src={builder.imgUrl} alt={builder.name} />
+                  <a
+                    href={builder.link}
+                    className="mt-2 block text-blue-600 hover:underline font-medium"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {builder.name}
+                  </a>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Builders;

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,10 +1,7 @@
-import type { NextPage } from "next";
-import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+"use client";
 
-export const metadata = getMetadata({
-  title: "Builders",
-  description: "List of members of the batch #9",
-});
+import type { NextPage } from "next";
+import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 
 const getRandomGender = () => {
   return Math.random() < 0.5 ? "men" : "women";
@@ -18,26 +15,48 @@ const getRandomUserImage = () => {
 };
 
 const mentors = [
-  { name: "Mentor 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000" },
-  { name: "Mentor 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000" },
-  { name: "Mentor 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000" },
+  { name: "Eda", imgUrl: "https://avatars.githubusercontent.com/u/22100698?v=4", link: "/builders/0x000000" },
+  { name: "Derrek", imgUrl: "https://avatars.githubusercontent.com/u/80121818?v=4", link: "/builders/0x000000" },
+  { name: "Philip", imgUrl: "https://avatars.githubusercontent.com/u/90064316?v=4", link: "/builders/0x000000" },
 ];
 
-const builders = [
-  { name: "Builder 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
-  { name: "Builder 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: false },
-  { name: "Builder 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
-  { name: "Builder 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
-  { name: "Builder 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: false },
-  { name: "Builder 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
-  { name: "Builder 1", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
-  { name: "Builder 2", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: false },
-  { name: "Builder 3", imgUrl: getRandomUserImage(), link: "/builders/0x000000", checkIn: true },
-];
+type Builder = {
+  image: string;
+  link: string;
+  checkedIn: boolean;
+};
+
+const getBuilderFromEvent = (event: any): Builder => {
+  const args = event.args;
+
+  const person: Builder = {
+    image: getRandomUserImage(),
+    link: "builders/" + args.builder,
+    checkedIn: true,
+  };
+
+  return person;
+};
 
 const Builders: NextPage = () => {
-  const totalBuilders = builders.length;
-  const buildersCheckedIn = builders.filter(builder => builder.checkIn).length;
+  const { data: events } = useScaffoldEventHistory({
+    contractName: "BatchRegistry",
+    eventName: "CheckedIn",
+    fromBlock: 31231n,
+    watch: true,
+    filters: { first: true } as any,
+    blockData: true,
+    transactionData: true,
+    receiptData: true,
+  });
+
+  let buildersCheckedIn = 0;
+  let builders: Builder[] = [];
+
+  if (events != undefined) {
+    buildersCheckedIn = events.length;
+    builders = events.map(e => getBuilderFromEvent(e));
+  }
 
   return (
     <>
@@ -50,8 +69,8 @@ const Builders: NextPage = () => {
           <div className="mb-12">
             <h2 className="text-2xl font-semibold text-center mb-6">Mentors</h2>
             <div className="grid grid-cols-3 gap-6">
-              {mentors.map(mentor => (
-                <div key={mentor.name} className="text-center">
+              {mentors.map((mentor, i) => (
+                <div key={i} className="text-center">
                   <img className="w-24 h-24 rounded-full mx-auto" src={mentor.imgUrl} alt={mentor.name} />
                   <a
                     href={mentor.link}
@@ -68,20 +87,18 @@ const Builders: NextPage = () => {
 
           <div>
             <h2 className="text-2xl font-semibold text-center mb-6">Builders 🏗</h2>
-            <p className="text-sm font-bold text-center mb-8">
-              Builders that checkedIn: {buildersCheckedIn} de {totalBuilders}
-            </p>
+            <p className="text-sm font-bold text-center mb-8">Builders that checkedIn: {buildersCheckedIn}</p>
             <div className="grid grid-cols-5 gap-20">
-              {builders.map(builder => (
-                <div key={builder.name} className="text-center">
-                  <img className="w-24 h-24 rounded-full mx-auto" src={builder.imgUrl} alt={builder.name} />
+              {builders.map((builder, i) => (
+                <div key={i} className="text-center">
                   <a
                     href={builder.link}
                     className="mt-2 block text-blue-600 hover:underline font-medium"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {builder.name}
+                    <img className="w-24 h-24 rounded-full mx-auto" src={builder.image} alt={builder.link} />
+                    See profile
                   </a>
                 </div>
               ))}

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -27,19 +27,19 @@ const mentors: Mentor[] = [
   {
     name: "Eda",
     image: "https://avatars.githubusercontent.com/u/22100698?v=4",
-    link: "/builders/0x000000",
+    link: "https://github.com/edakturk14",
     checkedIn: false,
   },
   {
     name: "Derrek",
     image: "https://avatars.githubusercontent.com/u/80121818?v=4",
-    link: "/builders/0x000000",
+    link: "https://github.com/derrekcoleman",
     checkedIn: false,
   },
   {
     name: "Philip",
     image: "https://avatars.githubusercontent.com/u/90064316?v=4",
-    link: "/builders/0x000000",
+    link: "https://github.com/phipsae",
     checkedIn: false,
   },
 ];

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import type { NextPage } from "next";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 
@@ -71,7 +72,13 @@ const Builders: NextPage = () => {
             <div className="grid grid-cols-3 gap-6">
               {mentors.map((mentor, i) => (
                 <div key={i} className="text-center">
-                  <img className="w-24 h-24 rounded-full mx-auto" src={mentor.imgUrl} alt={mentor.name} />
+                  <Image
+                    width={100}
+                    height={100}
+                    className="w-24 h-24 rounded-full mx-auto"
+                    src={mentor.imgUrl}
+                    alt={mentor.name}
+                  />
                   <a
                     href={mentor.link}
                     className="mt-2 block text-blue-600 hover:underline font-medium"
@@ -97,7 +104,13 @@ const Builders: NextPage = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <img className="w-24 h-24 rounded-full mx-auto" src={builder.image} alt={builder.link} />
+                    <Image
+                      width={100}
+                      height={100}
+                      className="w-24 h-24 rounded-full mx-auto"
+                      src={builder.image}
+                      alt={builder.link}
+                    />
                     See profile
                   </a>
                 </div>

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ProfilePicture } from "./_components/ProfilePicture";
+import { BuilderPicture, MentorPicture } from "./_components/index";
 import type { NextPage } from "next";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
-import { Builder } from "~~/types/builders";
+import { Builder, Mentor } from "~~/types/builders";
 
 const getRandomGender = () => {
   return Math.random() < 0.5 ? "men" : "women";
@@ -16,7 +16,19 @@ const getRandomUserImage = () => {
   return `https://randomuser.me/api/portraits/${randomGender}/${randomInt}.jpg`;
 };
 
-const mentors: Builder[] = [
+const getBuilderFromEvent = (event: any): Builder => {
+  const args = event.args;
+
+  const person: Builder = {
+    image: getRandomUserImage(),
+    link: "builders/" + args.builder,
+    checkedIn: true,
+  };
+
+  return person;
+};
+
+const mentors: Mentor[] = [
   {
     name: "Eda",
     image: "https://avatars.githubusercontent.com/u/22100698?v=4",
@@ -36,18 +48,6 @@ const mentors: Builder[] = [
     checkedIn: false,
   },
 ];
-
-const getBuilderFromEvent = (event: any): Builder => {
-  const args = event.args;
-
-  const person: Builder = {
-    image: getRandomUserImage(),
-    link: "builders/" + args.builder,
-    checkedIn: true,
-  };
-
-  return person;
-};
 
 const Builders: NextPage = () => {
   const { data: events } = useScaffoldEventHistory({
@@ -80,7 +80,7 @@ const Builders: NextPage = () => {
             <h2 className="text-2xl font-semibold text-center mb-6">Mentors</h2>
             <div className="grid grid-cols-3 gap-6">
               {mentors.map((mentor, i) => (
-                <ProfilePicture builder={mentor} key={i} />
+                <MentorPicture person={mentor} key={i} />
               ))}
             </div>
           </div>
@@ -90,7 +90,7 @@ const Builders: NextPage = () => {
             <p className="text-sm font-bold text-center mb-8">Builders that checkedIn: {buildersCheckedIn}</p>
             <div className="grid grid-cols-5 gap-20">
               {builders.map((builder, i) => (
-                <ProfilePicture builder={builder} key={i} />
+                <BuilderPicture person={builder} key={i} />
               ))}
             </div>
           </div>

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -17,17 +17,11 @@ const getRandomUserImage = () => {
   return `https://randomuser.me/api/portraits/${randomGender}/${randomInt}.jpg`;
 };
 
-const getBuilderFromEvent = (event: any): Builder => {
-  const args = event.args;
-
-  const person: Builder = {
-    image: getRandomUserImage(),
-    link: "builders/" + args.builder,
-    checkedIn: true,
-  };
-
-  return person;
-};
+const getBuilderFromEvent = (event: any): Builder => ({
+  image: getRandomUserImage(),
+  link: "builders/" + event.args.builder,
+  checkedIn: true,
+});
 
 const mentors: Mentor[] = [
   {

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -42,14 +42,11 @@ const Builders: NextPage = () => {
   return (
     <>
       <div className="text-center bg-secondary p-10">
-        <h1 className="text-4xl my-0">Builders</h1>
+        <h1 className="text-4xl my-0">Batch #9 people 💻 </h1>
       </div>
+
       <div className="max-w-screen-lg mx-auto mt-10 p-6 bg-base-300 shadow-md rounded-lg">
         <div className="container mx-auto px-4 py-8">
-          <h1 className="text-sm font-bold text-center mb-8">
-            Builders that checkedIn: {buildersCheckedIn} de {totalBuilders}
-          </h1>
-
           <div className="mb-12">
             <h2 className="text-2xl font-semibold text-center mb-6">Mentors</h2>
             <div className="grid grid-cols-3 gap-6">
@@ -71,7 +68,10 @@ const Builders: NextPage = () => {
 
           <div>
             <h2 className="text-2xl font-semibold text-center mb-6">Builders 🏗</h2>
-            <div className="grid grid-cols-6 gap-6">
+            <p className="text-sm font-bold text-center mb-8">
+              Builders that checkedIn: {buildersCheckedIn} de {totalBuilders}
+            </p>
+            <div className="grid grid-cols-5 gap-20">
               {builders.map(builder => (
                 <div key={builder.name} className="text-center">
                   <img className="w-24 h-24 rounded-full mx-auto" src={builder.imgUrl} alt={builder.name} />

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { BuilderPicture, MentorPicture } from "./_components/index";
 import type { NextPage } from "next";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
@@ -50,7 +51,10 @@ const mentors: Mentor[] = [
 ];
 
 const Builders: NextPage = () => {
-  const { data: events } = useScaffoldEventHistory({
+  const [buildersCheckedIn, setBuildersCheckedIn] = useState(0);
+  const [builders, setBuilders] = useState<Builder[]>([]);
+
+  const { data: events, isLoading: isLoadingEvents } = useScaffoldEventHistory({
     contractName: "BatchRegistry",
     eventName: "CheckedIn",
     fromBlock: 31231n,
@@ -61,13 +65,12 @@ const Builders: NextPage = () => {
     receiptData: true,
   });
 
-  let buildersCheckedIn = 0;
-  let builders: Builder[] = [];
-
-  if (events != undefined) {
-    buildersCheckedIn = events.length;
-    builders = events.map(e => getBuilderFromEvent(e));
-  }
+  useEffect(() => {
+    if (!isLoadingEvents && events != undefined) {
+      setBuildersCheckedIn(events.length);
+      setBuilders(events.map(e => getBuilderFromEvent(e)));
+    }
+  }, [isLoadingEvents, events]);
 
   return (
     <>

--- a/packages/nextjs/app/builders/page.tsx
+++ b/packages/nextjs/app/builders/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import Image from "next/image";
+import { ProfilePicture } from "./_components/ProfilePicture";
 import type { NextPage } from "next";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
+import { Builder } from "~~/types/builders";
 
 const getRandomGender = () => {
   return Math.random() < 0.5 ? "men" : "women";
@@ -15,17 +16,26 @@ const getRandomUserImage = () => {
   return `https://randomuser.me/api/portraits/${randomGender}/${randomInt}.jpg`;
 };
 
-const mentors = [
-  { name: "Eda", imgUrl: "https://avatars.githubusercontent.com/u/22100698?v=4", link: "/builders/0x000000" },
-  { name: "Derrek", imgUrl: "https://avatars.githubusercontent.com/u/80121818?v=4", link: "/builders/0x000000" },
-  { name: "Philip", imgUrl: "https://avatars.githubusercontent.com/u/90064316?v=4", link: "/builders/0x000000" },
+const mentors: Builder[] = [
+  {
+    name: "Eda",
+    image: "https://avatars.githubusercontent.com/u/22100698?v=4",
+    link: "/builders/0x000000",
+    checkedIn: false,
+  },
+  {
+    name: "Derrek",
+    image: "https://avatars.githubusercontent.com/u/80121818?v=4",
+    link: "/builders/0x000000",
+    checkedIn: false,
+  },
+  {
+    name: "Philip",
+    image: "https://avatars.githubusercontent.com/u/90064316?v=4",
+    link: "/builders/0x000000",
+    checkedIn: false,
+  },
 ];
-
-type Builder = {
-  image: string;
-  link: string;
-  checkedIn: boolean;
-};
 
 const getBuilderFromEvent = (event: any): Builder => {
   const args = event.args;
@@ -64,30 +74,13 @@ const Builders: NextPage = () => {
       <div className="text-center bg-secondary p-10">
         <h1 className="text-4xl my-0">Batch #9 people 💻 </h1>
       </div>
-
       <div className="max-w-screen-lg mx-auto mt-10 p-6 bg-base-300 shadow-md rounded-lg">
         <div className="container mx-auto px-4 py-8">
           <div className="mb-12">
             <h2 className="text-2xl font-semibold text-center mb-6">Mentors</h2>
             <div className="grid grid-cols-3 gap-6">
               {mentors.map((mentor, i) => (
-                <div key={i} className="text-center">
-                  <Image
-                    width={100}
-                    height={100}
-                    className="w-24 h-24 rounded-full mx-auto"
-                    src={mentor.imgUrl}
-                    alt={mentor.name}
-                  />
-                  <a
-                    href={mentor.link}
-                    className="mt-2 block text-blue-600 hover:underline font-medium"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {mentor.name}
-                  </a>
-                </div>
+                <ProfilePicture builder={mentor} key={i} />
               ))}
             </div>
           </div>
@@ -97,23 +90,7 @@ const Builders: NextPage = () => {
             <p className="text-sm font-bold text-center mb-8">Builders that checkedIn: {buildersCheckedIn}</p>
             <div className="grid grid-cols-5 gap-20">
               {builders.map((builder, i) => (
-                <div key={i} className="text-center">
-                  <a
-                    href={builder.link}
-                    className="mt-2 block text-blue-600 hover:underline font-medium"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Image
-                      width={100}
-                      height={100}
-                      className="w-24 h-24 rounded-full mx-auto"
-                      src={builder.image}
-                      alt={builder.link}
-                    />
-                    See profile
-                  </a>
-                </div>
+                <ProfilePicture builder={builder} key={i} />
               ))}
             </div>
           </div>

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -20,6 +20,10 @@ export const menuLinks: HeaderMenuLink[] = [
     href: "/",
   },
   {
+    label: "Builders",
+    href: "/builders",
+  },
+  {
     label: "Debug Contracts",
     href: "/debug",
     icon: <BugAntIcon className="h-4 w-4" />,

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -14,6 +14,22 @@ const nextConfig = {
     config.externals.push("pino-pretty", "lokijs", "encoding");
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        port: '',
+        pathname: '/u/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'randomuser.me',
+        port: '',
+        pathname: '/api/portraits/**',
+      }
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/packages/nextjs/types/builders.ts
+++ b/packages/nextjs/types/builders.ts
@@ -1,6 +1,7 @@
 export type Builder = {
   image: string;
-  link: string;
+  profileLink: string;
+  address?: `0x${string}`;
   checkedIn: boolean;
 };
 

--- a/packages/nextjs/types/builders.ts
+++ b/packages/nextjs/types/builders.ts
@@ -1,6 +1,9 @@
 export type Builder = {
-  name?: string;
   image: string;
   link: string;
   checkedIn: boolean;
+};
+
+export type Mentor = Builder & {
+  name: string;
 };

--- a/packages/nextjs/types/builders.ts
+++ b/packages/nextjs/types/builders.ts
@@ -1,0 +1,6 @@
+export type Builder = {
+  name?: string;
+  image: string;
+  link: string;
+  checkedIn: boolean;
+};


### PR DESCRIPTION
## Description

Created a page to display a list of builders and mentors. The page features:

- A section for mentors with their photos, names, and links to their personal pages.

- A section for builders with similar details.

- A dynamic counter that shows how many builders have checked in out of the total.

You can see a first template:

![image](https://github.com/user-attachments/assets/839c5e55-1df0-402b-b93a-c15cdd973a39)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #7_

Your ENS/address: 0xaa4C60b784E2b3E485035399bF1b1aBDeD66A60f
